### PR TITLE
feat(git): strengthen git-strategies with commit-why, draft-PR, and worktree rules

### DIFF
--- a/.agent/rules/git-strategies.md
+++ b/.agent/rules/git-strategies.md
@@ -7,6 +7,23 @@
 - **読める**: diff を見て「何をしたか」が30秒で分かる
 - **戻せる**: このコミットだけ revert しても壊れない
 - **説明できる**: コミットメッセージが1行で書ける
+- **意図がある**: Why（なぜこの変更か）を書く。What だけでは不十分
+
+### コミットメッセージのフォーマット
+
+```
+type(scope): what
+
+Why: なぜこの変更が必要か（1-2行）
+```
+
+例:
+
+```
+feat(git): add pre-commit branch check rule
+
+Why: エージェントが main に直接コミットする習慣を構造的に防止する
+```
 
 ### やるべき分割
 
@@ -40,8 +57,15 @@ main ← マージだけ。直接コミットしない
 
 1. **作業開始 → まずブランチを切る**: `git checkout -b feat/xxx`
 2. **1ブランチ = 1目的**（機能、修正、リファクタ）
-3. 完了 → main にマージ + ブランチ削除
-4. main に直接コミットしていい例外: **typo 修正のみ**
+3. 完了 → **Draft PR を作成**（マージは人間が判断）
+4. レビュー後 → main にマージ + ブランチ削除
+5. main に直接コミットしていい例外: **typo 修正のみ**
+
+### Draft PR ルール
+
+- エージェントは **Draft PR のみ** 作成する。Ready にしない
+- PR 説明に「何をしたか」「なぜ」「テスト結果」を含める
+- マージは**人間が判断**する。エージェントはマージしない
 
 ### ブランチを切るタイミング
 
@@ -83,9 +107,42 @@ main ← マージだけ。直接コミットしない
 2. **方向転換する前** — 戻れるセーブポイントを作る
 3. **1つの作業単位が完了した**とき — 中途半端にしない
 
+## Multi-Agent: Git Worktree
+
+複数エージェントが同じリポジトリで並列作業する場合、**worktree** を使う。
+
+```powershell
+# Agent A: feat/skill-update を作業
+git worktree add ../skills-my-util-A feat/skill-update
+
+# Agent B: fix/setup-bug を作業
+git worktree add ../skills-my-util-B fix/setup-bug
+```
+
+### Worktree ルール
+
+| ルール | 理由 |
+| --- | --- |
+| 1 worktree = 1 ブランチ = 1 エージェント | コンテキスト混在を防ぐ |
+| 作業完了後は `git worktree remove` | ゴミを残さない |
+| main の worktree は作らない | main は受け取るだけ |
+| worktree 内で別ブランチに checkout しない | worktree の意味がなくなる |
+
+### 並列作業フロー
+
+```mermaid
+flowchart LR
+    M[main] -->|branch| A[feat/xxx\nAgent A]
+    M -->|branch| B[fix/yyy\nAgent B]
+    A -->|Draft PR| M
+    B -->|Draft PR| M
+```
+
 ## Anti-Patterns
 
 - ❌ ブランチを切らずに main で大規模変更
 - ❌ 動作確認前にコミット（壊れた状態を保存しない）
 - ❌ 長時間コミットしない（クラッシュ時にすべて失う）
 - ❌ WIP コミットを大量に積む（後でまとめることを前提にしない）
+- ❌ エージェントが PR をマージする（人間の判断を奪わない）
+- ❌ 1つの worktree で複数ブランチを切り替える


### PR DESCRIPTION
## 概要
Git運用ルール (`.agent/rules/git-strategies.md`) の強化。

## 変更内容
- **commit-why ルール**: コミットメッセージに Why（変更理由）の記載を必須化
- **Draft PR ルール**: エージェントは Draft PR のみ作成し、マージは人間が判断する運用を明文化
- **main-is-receive-only**: main への直接コミット禁止を最重要ルールとして明確化
- **Git Worktree**: 複数エージェント並列作業時の worktree 運用ルールとフロー図を追加
- **Pre-commit Check**: ブランチ確認を毎回実施するチェックリストを追加

## Why
エージェントが main を汚染する事故を構造的に防止し、マルチエージェント環境でのGit運用を標準化するため。

## 影響範囲
- `.agent/rules/git-strategies.md` のみ（84行追加、4行削除）
- 既存の動作に破壊的変更なし