### PR TITLE
docs: gh-commands.md with label taxonomy and issue-driven workflow

### DIFF
--- a/skills/task-coordination/SKILL.md
+++ b/skills/task-coordination/SKILL.md
@@ -88,14 +88,20 @@ gh issue close <number> --comment "Done: <summary>"
 
 ### Step 4: Sync (Session Start)
 
-On every session start, check for existing project state:
+On every session start, check for existing project state.
+See [references/gh-commands.md](references/gh-commands.md) for full command patterns.
 
 ```bash
-gh issue list --state open --json number,title,labels
-gh issue list --label "blocked:human" --json number,title
+gh issue list --state open --json number,title,labels,assignees --limit 50
 ```
 
-**If open issues exist** — check CozoDB for detailed status (if available).
+**Issue-driven チェック:**
+
+1. **自分に assign されている Issue** → 優先着手（前回の続き）
+2. **`blocked:human` Issue** → ユーザーに即報告
+3. **`priority:high` Issue** → 着手候補として提示
+4. **今の作業と関連する Issue** → リンクまたは重複確認
+5. **新規 Issue を作る前** → 既存 Issue との重複を `gh search issues` でチェック
 
 **If blocked:human issues exist** — surface them immediately to the user.
 

--- a/skills/task-coordination/references/gh-commands.md
+++ b/skills/task-coordination/references/gh-commands.md
@@ -1,59 +1,154 @@
-# gh CLI Quick Reference
+# gh CLI Reference
 
 Task coordination で使用する `gh` コマンドのリファレンス。
 
-## Initial Setup
+境界設計: [docs/task-state-boundary.md](../../../docs/task-state-boundary.md)
 
-プロジェクトに必要なラベルを一括作成:
+## Label Taxonomy
 
-```powershell
-$labels = @(
-    @{ name = "status:planned";     color = "c5def5"; description = "Not yet started" }
-    @{ name = "status:in-progress"; color = "0e8a16"; description = "Being worked on" }
-    @{ name = "status:blocked";     color = "d93f0b"; description = "Waiting on something" }
-    @{ name = "blocked:human";      color = "e4e669"; description = "Human action required" }
-    @{ name = "blocked:external";   color = "fbca04"; description = "Waiting on external dependency" }
-    @{ name = "critical-path";      color = "b60205"; description = "Delay here delays everything" }
-    @{ name = "priority:high";      color = "d93f0b"; description = "Should be picked up next" }
-)
+ラベルは**分類と通知**に使う。状態管理には使わない（→ CozoDB）。
 
-foreach ($l in $labels) {
-    gh label create $l.name --color $l.color --description $l.description --force
-}
-```
+| Label | Color | Purpose |
+| --- | --- | --- |
+| `blocked:human` | `#B60205` | 人間のアクションが必要（通知トリガー） |
+| `blocked:external` | `#E99695` | 外部依存待ち |
+| `critical-path` | `#FBCA04` | 遅延がプロジェクト全体に影響 |
+| `priority:high` | `#D93F0B` | 次に着手すべき |
 
-## Common Operations
+### 廃止済み
 
-### Create issue
+`status:planned`, `status:in-progress`, `status:blocked` — GitHub の Open/Closed + CozoDB が代替。
+
+### Label Setup
+
+新しいリポジトリにラベルを一括作成:
 
 ```bash
-gh issue create --title "Implement auth" --body "AC: login/logout works" --label "status:planned"
+gh label create "blocked:human"    --color "B60205" --description "Human action required" --force
+gh label create "blocked:external" --color "E99695" --description "Waiting on external dependency" --force
+gh label create "critical-path"    --color "FBCA04" --description "Delay here delays everything" --force
+gh label create "priority:high"    --color "D93F0B" --description "Should be picked up next" --force
 ```
 
-### Start work
+### Label Rules
+
+- taxonomy にないラベルは勝手に作らない
+- ラベルの追加・変更はユーザーに確認してから
+- 他のリポからコピーする場合: `gh label clone SOURCE_REPO`
+
+## Issue Operations
+
+### Create
 
 ```bash
-gh issue edit 42 --add-label "status:in-progress" --remove-label "status:planned"
+gh issue create \
+  --title "feat: implement auth" \
+  --body "## Acceptance Criteria
+- [ ] Login/logout works
+- [ ] Token refresh handled" \
+  --label "priority:high"
 ```
 
-### Mark blocked
+**ルール**:
+- タイトルは `type: what` フォーマット（Conventional Commits に準拠）
+- body に Acceptance Criteria を必ず含める
+- 状態ラベルは付けない（Open = 未完了、Closed = 完了）
+
+### Block
 
 ```bash
-gh issue edit 42 --add-label "status:blocked,blocked:human" --remove-label "status:in-progress"
 gh issue comment 42 --body "Blocked: waiting for @user to approve design doc"
+gh issue edit 42 --add-label "blocked:human"
 ```
 
 ### Complete
 
 ```bash
-gh issue close 42 --comment "Done: implemented auth with Firebase"
+gh issue close 42 --comment "Done: implemented auth with Firebase. PR #10"
 ```
 
-### Session start sync
+## Issue Check on Session Start
+
+**Issue-driven の核心**: 作業開始前に必ず既存 Issue を確認し、関連性をチェックする。
+
+### Step 1: Open Issues を取得
 
 ```bash
-gh issue list --label "status:in-progress" --json number,title,assignees
-gh issue list --label "status:blocked" --json number,title,labels
-gh issue list --label "critical-path" --state open --json number,title
-gh issue list --state open --json number,title,labels --limit 50
+gh issue list --state open --json number,title,labels,assignees --limit 50
 ```
+
+### Step 2: 関連性を判断
+
+取得した Issue リストに対して:
+
+1. **自分に assign されている** → 優先的に着手（前回の続き）
+2. **`blocked:human` ラベル** → ユーザーに即報告
+3. **`priority:high` ラベル** → 着手候補として提示
+4. **今の作業と関連する** → リンクまたは重複を確認
+
+### Step 3: 重複チェック
+
+新しい Issue を作る前に、既存 Issue との重複を確認:
+
+```bash
+gh search issues "keyword" --repo OWNER/REPO --state open --json number,title
+```
+
+重複がある場合:
+- 同じ目的 → 既存 Issue に合流（新規作成しない）
+- 部分的に重複 → コメントで相互参照を付ける
+- 関連あるが別タスク → 新規作成して `Relates to #N` を body に記載
+
+## PR Operations
+
+### Draft PR（エージェントのデフォルト）
+
+```bash
+gh pr create \
+  --base main \
+  --head feat/xxx \
+  --draft \
+  --title "feat: what this PR does" \
+  --body "## Summary
+What and why.
+
+## Changes
+- File changes listed
+
+## Related
+Closes #42"
+```
+
+**ルール**:
+- エージェントは **Draft PR のみ** 作成する
+- `Closes #N` で Issue を自動リンク
+- マージは人間が判断
+
+### PR Status Check
+
+```bash
+gh pr list --state open --json number,title,headRefName,isDraft
+gh pr view 1 --json state,mergeable,reviewDecision
+```
+
+## Cross-Repo Search
+
+```bash
+# Issue 検索（キーワード）
+gh search issues "auth" --owner AtsushiYamashita --state open
+
+# PR 検索
+gh search prs "refactor" --repo OWNER/REPO --state open
+
+# コミット検索
+gh search commits "fix login" --repo OWNER/REPO
+```
+
+## Anti-Patterns
+
+- ❌ taxonomy にないラベルを勝手に作る
+- ❌ Acceptance Criteria なしの Issue
+- ❌ 既存 Issue を確認せずに新規作成（重複の原因）
+- ❌ PR を Ready にする（Draft のみ）
+- ❌ Issue を Close せずに PR だけマージ（`Closes #N` を使う）
+- ❌ status:* ラベルを使う（廃止済み）


### PR DESCRIPTION
## Summary

Rewrites `gh-commands.md` to align with PR #2 changes (status:* label removal) and adds issue-driven workflow.

## Changes
- **Label Taxonomy**: Classification-only labels with setup commands
- **Issue Check on Session Start**: 5-step flow for checking existing issues before starting work
- **Duplicate Check**: `gh search issues` before creating new issues
- **PR Conventions**: Draft PR patterns with `Closes #N` linking
- **task-coordination/SKILL.md**: Step 4 updated with issue-driven checklist

## Why
Issue-driven development requires agents to check existing issues for relevance before starting work, preventing duplicates and ensuring continuity.

Closes #3