### PR TITLE
refactor(setup): split setup.ps1 into 4 files by responsibility

### DIFF
--- a/scripts/lib/config-sync.ps1
+++ b/scripts/lib/config-sync.ps1
@@ -1,0 +1,41 @@
+<#
+.SYNOPSIS
+    Synchronize global configuration files (GEMINI.md, rules, workflows).
+#>
+
+function Sync-GeminiMd(
+    [string]$RepoRoot,
+    [string]$GlobalConfig,
+    [string]$BackupSuffix,
+    [bool]$IsUnlink,
+    [bool]$HasSkillNames
+) {
+    <# GEMINI.md のグローバル symlink を設定/解除する #>
+    $repoGeminiMd = Join-Path $RepoRoot $GlobalConfig
+    $globalGeminiMd = Join-Path $env:USERPROFILE (Join-Path ".gemini" $GlobalConfig)
+
+    if (-not (Test-Path $repoGeminiMd)) { return }
+    if ($IsUnlink -and $HasSkillNames) { return }                        # 個別スキル削除時は触らない
+
+    # ---- Unlink mode ----
+    if ($IsUnlink) {
+        if (-not (Test-Path $globalGeminiMd)) { return }
+        $item = Get-Item $globalGeminiMd -Force
+        if (-not ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) { return }
+        $item.Delete()
+        Write-Host "  Unlinked: GEMINI.md" -ForegroundColor Yellow
+        return
+    }
+
+    # ---- Install mode ----
+    if (Test-Path $globalGeminiMd) {
+        $item = Get-Item $globalGeminiMd -Force
+        if ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) { return }  # 設定済み
+        $backupPath = "${globalGeminiMd}${BackupSuffix}"
+        Move-Item $globalGeminiMd $backupPath -Force
+        New-SymlinkOrCopy $globalGeminiMd $repoGeminiMd "GEMINI.md (backup: $backupPath)"
+        return
+    }
+
+    New-SymlinkOrCopy $globalGeminiMd $repoGeminiMd "GEMINI.md -> $repoGeminiMd"
+}

--- a/scripts/lib/skill-discovery.ps1
+++ b/scripts/lib/skill-discovery.ps1
@@ -1,0 +1,122 @@
+<#
+.SYNOPSIS
+    Skill discovery, resolution, and display.
+#>
+
+function Write-SkillInfo(
+    [System.IO.DirectoryInfo]$Item,
+    [string]$SkillManifest,
+    [string]$RepoSkillsDir
+) {
+    <# 1つのスキルの情報を1行で表示する #>
+    $isSymlink = $Item.Attributes -band [IO.FileAttributes]::ReparsePoint
+    $hasSkillMd = Test-Path (Join-Path $Item.FullName $SkillManifest)
+    $isLocal = Test-MonorepoSymlink $Item $RepoSkillsDir
+
+    $icon = if ($isLocal) { "📦" } elseif ($isSymlink) { "🔗" } else { "📁" }
+    $source = if ($isLocal) { "monorepo" } elseif ($isSymlink) { "external" } else { "direct" }
+    $skillMdTag = if ($hasSkillMd) { "" } else { " [no $SkillManifest]" }
+
+    Write-Host "  $icon $($Item.Name)" -ForegroundColor White -NoNewline
+    Write-Host " ($source)$skillMdTag" -ForegroundColor DarkGray
+}
+
+function Show-InstalledSkills(
+    [string]$TargetDir,
+    [string]$Target,
+    [string]$SkillManifest,
+    [string]$RepoSkillsDir
+) {
+    <# インストール済みスキルの一覧を表示する #>
+    if (-not (Test-Path $TargetDir)) {
+        Write-Host "No skills directory found for $Target" -ForegroundColor Yellow
+        Write-Host "Expected: $TargetDir" -ForegroundColor DarkGray
+        return
+    }
+
+    $items = Get-ChildItem -Path $TargetDir -Directory -Force -ErrorAction SilentlyContinue
+    if (-not $items -or $items.Count -eq 0) {
+        Write-Host "No skills installed for $Target" -ForegroundColor Yellow
+        return
+    }
+
+    Write-Host ""
+    Write-Host "Installed skills for $Target" -ForegroundColor Cyan
+    Write-Host "Path: $TargetDir" -ForegroundColor DarkGray
+    Write-Host ""
+
+    foreach ($item in $items) { Write-SkillInfo $item $SkillManifest $RepoSkillsDir }
+
+    $localCount = @($items | Where-Object { Test-MonorepoSymlink $_ $RepoSkillsDir }).Count
+    $externalCount = $items.Count - $localCount
+    Write-Host ""
+    Write-Host "Total: $($items.Count) skill(s) — $localCount monorepo, $externalCount other" -ForegroundColor Cyan
+}
+
+function Get-SkillsToProcess(
+    [bool]$IsUnlink,
+    [string[]]$Names,
+    [string]$TargetDir,
+    [string]$RepoSkillsDir,
+    [string]$SkillManifest
+) {
+    <# パラメータに応じて処理対象スキルを解決する #>
+    $hasNames = $null -ne $Names -and $Names.Count -gt 0
+    $mode = if ($IsUnlink -and $hasNames) { "UnlinkSpecific" }
+    elseif ($IsUnlink) { "UnlinkAll" }
+    elseif ($hasNames) { "InstallSpecific" }
+    else { "InstallAll" }
+
+    switch ($mode) {
+        "UnlinkSpecific" {
+            $result = @()
+            foreach ($name in $Names) {
+                $path = Join-Path $TargetDir $name
+                if (-not (Test-Path $path)) { Write-Warning "Not installed: $name"; continue }
+                $result += Get-Item $path -Force
+            }
+            return $result
+        }
+        "UnlinkAll" {
+            if (-not (Test-Path $TargetDir)) { return @() }
+            return @(Get-ChildItem -Path $TargetDir -Directory |
+                Where-Object { $_.Attributes -band [IO.FileAttributes]::ReparsePoint })
+        }
+        "InstallSpecific" {
+            $result = @()
+            foreach ($name in $Names) {
+                $path = Join-Path $RepoSkillsDir $name
+                if (-not (Test-Path $path)) { Write-Error "Skill not found in repo: $name (expected at $path)" }
+                $result += Get-Item $path
+            }
+            return $result
+        }
+        "InstallAll" {
+            return @(Get-ChildItem -Path $RepoSkillsDir -Directory |
+                Where-Object { Test-Path (Join-Path $_.FullName $SkillManifest) })
+        }
+    }
+}
+
+function Show-CozoDbHint(
+    [string]$TargetDir,
+    [string]$CozoDbSkill,
+    [string[]]$CozoDbUrls
+) {
+    <# CozoDB 依存のヒントを表示する #>
+    $cozoSkillPath = Join-Path $TargetDir $CozoDbSkill
+    if (Test-Path $cozoSkillPath) {
+        Write-Host "  CozoDB: detected" -ForegroundColor Green
+        return
+    }
+
+    Write-Host ""
+    Write-Host "=== CozoDB not detected ===" -ForegroundColor Yellow
+    Write-Host "  task-state (orphan detection, decision prediction) requires CozoDB." -ForegroundColor DarkGray
+    Write-Host "  To enable:" -ForegroundColor DarkGray
+    for ($i = 0; $i -lt $CozoDbUrls.Count; $i++) {
+        Write-Host "    $($i + 1). $($CozoDbUrls[$i])" -ForegroundColor White
+    }
+    Write-Host "  Then re-run this script." -ForegroundColor DarkGray
+    Write-Host "  (CozoDB is optional. Core skills work without it.)" -ForegroundColor DarkGray
+}

--- a/scripts/lib/symlink-ops.ps1
+++ b/scripts/lib/symlink-ops.ps1
@@ -1,0 +1,76 @@
+<#
+.SYNOPSIS
+    Symlink CRUD operations with copy fallback.
+#>
+
+function New-SymlinkOrCopy([string]$LinkPath, [string]$TargetPath, [string]$Label) {
+    <# symlink を作成し、失敗時はコピーにフォールバックする #>
+    try {
+        New-Item -ItemType SymbolicLink -Path $LinkPath -Target $TargetPath | Out-Null
+        Write-Host "  Linked: $Label" -ForegroundColor Green
+    }
+    catch {
+        Copy-Item -Path $TargetPath -Destination $LinkPath -Force
+        Write-Host "  Copied: $Label" -ForegroundColor Cyan
+    }
+}
+
+function Test-MonorepoSymlink([System.IO.DirectoryInfo]$Item, [string]$RepoSkillsDir) {
+    <# このリポジトリへの symlink かどうかを判定する #>
+    if (-not ($Item.Attributes -band [IO.FileAttributes]::ReparsePoint)) { return $false }
+    $t = $Item.Target
+    return ($null -ne $t) -and ($t.StartsWith($RepoSkillsDir))
+}
+
+function Install-SkillLink(
+    [System.IO.DirectoryInfo]$Skill,
+    [string]$TargetDir,
+    [string]$BackupSuffix
+) {
+    <# 1つのスキルの symlink を作成する（競合処理・フォールバック含む） #>
+    $linkPath = Join-Path $TargetDir $Skill.Name
+
+    if (Test-Path $linkPath) {
+        $item = Get-Item $linkPath -Force
+        $isSymlink = $item.Attributes -band [IO.FileAttributes]::ReparsePoint
+
+        if ($isSymlink -and $item.Target -eq $Skill.FullName) { return }  # 既にリンク済み
+
+        if ($isSymlink) {
+            $item.Delete()                                                # 古い symlink → 再作成
+            Write-Host "  Relinked: $($Skill.Name) (was -> $($item.Target))" -ForegroundColor Yellow
+        }
+
+        if (-not $isSymlink) {
+            $backupPath = "${linkPath}${BackupSuffix}"                    # 通常ディレクトリ → バックアップ
+            if (Test-Path $backupPath) { Remove-Item $backupPath -Recurse -Force }
+            Move-Item $linkPath $backupPath -Force
+            Write-Host "  Replacing directory with symlink: $($Skill.Name) (backup: $backupPath)" -ForegroundColor Yellow
+        }
+    }
+
+    New-SymlinkOrCopy $linkPath $Skill.FullName "$($Skill.Name) -> $($Skill.FullName)"
+}
+
+function Remove-SkillLink(
+    [System.IO.DirectoryInfo]$Skill,
+    [string]$TargetDir
+) {
+    <# 1つのスキルの symlink を削除する #>
+    $linkPath = if ($Skill.FullName.StartsWith($TargetDir)) { $Skill.FullName }
+    else { Join-Path $TargetDir $Skill.Name }
+
+    if (-not (Test-Path $linkPath)) {
+        Write-Host "  Not found: $($Skill.Name)" -ForegroundColor DarkGray
+        return
+    }
+
+    $item = Get-Item $linkPath -Force
+    if (-not ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) {
+        Write-Warning "  Skipped (not a symlink): $linkPath"
+        return
+    }
+
+    $item.Delete()
+    Write-Host "  Removed: $($Skill.Name)" -ForegroundColor Yellow
+}


### PR DESCRIPTION
## What

322行の setup.ps1 を意味単位で4ファイルに分割。

| File | Lines | Responsibility |
|---|---|---|
| `setup.ps1` | 128 | Orchestrator (params, constants, paths, main loop) |
| `lib/symlink-ops.ps1` | 76 | Symlink CRUD (create, test, install, remove) |
| `lib/skill-discovery.ps1` | 117 | Skill resolution, display, CozoDB hint |
| `lib/config-sync.ps1` | 42 | Global config sync (GEMINI.md) |

## Why

- 322行は長すぎる。関数は分割済みだがファイルが1つのままだった
- 全関数を引数化しスクリプトスコープ変数への依存を排除
- config-sync.ps1 は今後 rules/workflows 同期を追加する受け皿

## Testing

- [x] `setup.ps1 -t antigravity` (全インストール)
- [x] `setup.ps1 -t antigravity -s change-sync` (個別インストール)
- [x] `setup.ps1 -t antigravity -Unlink -s change-sync` (個別削除)
- [x] `setup.ps1 -t antigravity -List` (一覧表示)
- [x] CozoDB detected 表示

## TODO (健全性検証)

- [ ] `-List` 出力の絵文字がターミナルエンコーディングで文字化けする（PS 5.1 + 非UTF-8コンソール）
- [ ] `Copied:` フォールバック時のパス表示が正しいか確認（管理者権限なし環境）
- [ ] `setup.ps1 -t antigravity -Unlink` (全削除) の動作確認
- [ ] `install-hooks.ps1` との `New-SymlinkOrCopy` 共有は未実施（将来の統合候補）